### PR TITLE
gq_tmap_classes(): expose per-class line widths

### DIFF
--- a/R/gq_tmap_style.R
+++ b/R/gq_tmap_style.R
@@ -50,7 +50,8 @@ gq_tmap_style <- function(layer_or_reg, name = NULL, field = NULL) {
 #' labels suitable for tmap's `tm_scale_categorical()`.
 #'
 #' @inheritParams gq_style
-#' @return A named list with `values` (named color vector), `labels`, and `field`.
+#' @return A named list with `field`, `values` (named color vector), `labels`,
+#'   and `widths` (named line-width vector for line layers; `NULL` otherwise).
 #'
 #' @examples
 #' path <- system.file("examples", "mini_registry.json", package = "gq")
@@ -61,6 +62,7 @@ gq_tmap_style <- function(layer_or_reg, name = NULL, field = NULL) {
 #' cls$field
 #' cls$values
 #' cls$labels
+#' cls$widths
 #'
 #' # Object-based (backwards compatible)
 #' cls <- gq_tmap_classes(reg$layers$road)
@@ -70,7 +72,8 @@ gq_tmap_classes <- function(layer_or_reg, name = NULL, field = NULL) {
   sty <- gq_style(layer_or_reg, name, field = field)
   cls <- sty$classification
   if (is.null(cls)) stop("Layer does not have classification")
-  list(field = cls$field, values = cls$values, labels = cls$labels)
+  list(field = cls$field, values = cls$values, labels = cls$labels,
+       widths = cls$widths)
 }
 
 

--- a/man/gq_template_layers.Rd
+++ b/man/gq_template_layers.Rd
@@ -14,7 +14,7 @@ loads via \code{\link[=gq_reg_main]{gq_reg_main()}}.}
 }
 \value{
 A data.frame with columns: template, group, group_order, subgroup,
-layer_key, order, source_layer, type.
+layer_key, order, source_layer, source_type, type.
 }
 \description{
 Expands a template through its groups to produce a flat data.frame of

--- a/man/gq_tmap_classes.Rd
+++ b/man/gq_tmap_classes.Rd
@@ -22,7 +22,8 @@ column name (e.g., bcfishpass \code{barrier_status} vs WHSE
 alternatives.}
 }
 \value{
-A named list with \code{values} (named color vector), \code{labels}, and \code{field}.
+A named list with \code{field}, \code{values} (named color vector), \code{labels},
+and \code{widths} (named line-width vector for line layers; \code{NULL} otherwise).
 }
 \description{
 For categorized/graduated layers, returns the field, color values, and
@@ -37,6 +38,7 @@ cls <- gq_tmap_classes(reg, "road")
 cls$field
 cls$values
 cls$labels
+cls$widths
 
 # Object-based (backwards compatible)
 cls <- gq_tmap_classes(reg$layers$road)


### PR DESCRIPTION
## Summary

- `gq_tmap_classes()` now returns the per-class `widths` vector alongside `field`/`values`/`labels`. The classification object that `gq_style()` builds already computed `widths` (and `gq`'s own `tmap_classified()` consumes it internally) — the public accessor was simply dropping it on return.
- Backward-compatible: additive named element. Existing callers index the return list by name (`cls$values`, `cls$labels`), so nothing breaks.
- Drive-by: resync the stale `gq_template_layers.Rd` `@return` (`source_type` column) picked up by `document()`.

## Motivation

`link`'s new PARS habitat-connectivity vignette styles stream segments with the bcfishpass symbology registry: colour keyed on barrier status, **line width keyed on habitat use** (SPAWN thick, REAR medium, ACCESS thin). Colour came through `cls$values[token]`; width needs the symmetric `cls$widths[token]`. Exposing `widths` keeps the registry the single source of truth rather than re-hardcoding the weights downstream.

## Related Issues

- Relates to NewGraphEnvironment/sred#13

## Notes

Follow-up tracked separately: `gq_style()` still drops other registry symbology dimensions (per-class `opacity`, line `casing_*`, `outline_*`) and `gq_tmap_classes()` still omits `radii`/`shapes`. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
