### PR TITLE
Capture QGIS dash on classified line layers (#32)

### DIFF
--- a/R/gq_qgs_extract.R
+++ b/R/gq_qgs_extract.R
@@ -119,6 +119,26 @@ opt_val <- function(layer_node, name) {
   xml2::xml_attr(node, "value")
 }
 
+#' Extract a dash pattern from a SimpleLine symbol layer
+#'
+#' QGIS encodes dashes two ways: a named `line_style` (e.g. "dash dot"), or a
+#' custom pattern flagged by `use_custom_dash="1"` + `customdash` (e.g. "0.66;2")
+#' with `line_style` left "solid". Returns the raw QGIS value — named style or
+#' custom pattern — or `NA` for a solid line. The custom-dash flag takes
+#' precedence, since QGIS keeps `line_style="solid"` even when a custom pattern
+#' is active.
+#' @noRd
+parse_dash <- function(layer_node) {
+  use_custom <- opt_val(layer_node, "use_custom_dash")
+  if (!is.na(use_custom) && use_custom == "1") {
+    custom <- opt_val(layer_node, "customdash")
+    if (!is.na(custom)) return(custom)
+  }
+  style <- opt_val(layer_node, "line_style")
+  if (!is.na(style) && style != "solid") return(style)
+  NA_character_
+}
+
 #' Parse a singleSymbol renderer
 #' @noRd
 parse_single_symbol <- function(renderer, geom_type) {
@@ -151,13 +171,11 @@ parse_single_symbol <- function(renderer, geom_type) {
   } else if (sym_class == "SimpleLine") {
     color <- opt_val(sym_layer, "line_color")
     width <- opt_val(sym_layer, "line_width")
-    style <- opt_val(sym_layer, "line_style")
-    dash <- opt_val(sym_layer, "customdash")
+    dash <- parse_dash(sym_layer)
 
     stroke <- list(color = rgba_to_hex(color))
     if (!is.na(width)) stroke$width <- as.numeric(width)
-    if (!is.na(style) && style != "solid") stroke$dash <- style
-    if (!is.na(dash) && !is.na(style) && style == "custom_dash") stroke$dash <- dash
+    if (!is.na(dash)) stroke$dash <- dash
 
     stroke_alpha <- sym_alpha * rgba_alpha(color)
     if (stroke_alpha < 1) stroke$opacity <- round(stroke_alpha, 3)
@@ -225,6 +243,8 @@ parse_categorized <- function(renderer, geom_type) {
       width <- opt_val(sym_layer, "line_width")
       cls$color <- rgba_to_hex(color)
       if (!is.na(width)) cls$width <- as.numeric(width)
+      dash <- parse_dash(sym_layer)
+      if (!is.na(dash)) cls$dash <- dash
       line_alpha <- sym_alpha * rgba_alpha(color)
       if (line_alpha < 1) cls$opacity <- round(line_alpha, 3)
     } else if (sym_class == "SimpleMarker") {

--- a/R/gq_style.R
+++ b/R/gq_style.R
@@ -18,7 +18,9 @@
 #' @return A named list with `type` and style properties. For simple layers:
 #'   `fill`, `stroke`, `mark` as applicable. For classified layers: adds
 #'   `classification` with `field`, `values` (named color vector), `labels`,
-#'   and per-class `widths`/`radii` when available.
+#'   and per-class `widths`/`radii`/`dashes` when available. `dashes` holds the
+#'   raw QGIS dash value (named style like "dash dot", or custom pattern like
+#'   "0.66;2") for classes that are dashed.
 #'
 #' @examples
 #' path <- system.file("examples", "mini_registry.json", package = "gq")
@@ -59,6 +61,7 @@ gq_style <- function(layer_or_reg, name = NULL, field = NULL) {
     widths <- vapply(cls$classes, function(x) x$width %||% NA_real_, numeric(1))
     radii <- vapply(cls$classes, function(x) x$radius %||% NA_real_, numeric(1))
     shapes <- vapply(cls$classes, function(x) x$shape %||% NA_character_, character(1))
+    dashes <- vapply(cls$classes, function(x) x$dash %||% NA_character_, character(1))
 
     # Remove __empty__ class
     keep <- keys != "__empty__"
@@ -67,6 +70,7 @@ gq_style <- function(layer_or_reg, name = NULL, field = NULL) {
     widths <- widths[keep]
     radii <- radii[keep]
     shapes <- shapes[keep]
+    dashes <- dashes[keep]
     keys <- keys[keep]
     names(values) <- keys
 
@@ -78,6 +82,7 @@ gq_style <- function(layer_or_reg, name = NULL, field = NULL) {
     if (!all(is.na(widths))) result$classification$widths <- widths
     if (!all(is.na(radii))) result$classification$radii <- radii
     if (!all(is.na(shapes))) result$classification$shapes <- shapes
+    if (!all(is.na(dashes))) result$classification$dashes <- dashes
 
     return(result)
   }

--- a/R/gq_tmap_style.R
+++ b/R/gq_tmap_style.R
@@ -51,7 +51,11 @@ gq_tmap_style <- function(layer_or_reg, name = NULL, field = NULL) {
 #'
 #' @inheritParams gq_style
 #' @return A named list with `field`, `values` (named color vector), `labels`,
-#'   and `widths` (named line-width vector for line layers; `NULL` otherwise).
+#'   `widths` (named line-width vector for line layers; `NULL` otherwise), and
+#'   `dashes` (named raw-QGIS-dash vector for classes that are dashed; `NULL`
+#'   otherwise). The dash value is the raw QGIS encoding (named style like
+#'   "dash dot", or custom pattern like "0.66;2") — consumers map it to their
+#'   backend's line type (e.g. tmap `lty = "dashed"` for non-NA entries).
 #'
 #' @examples
 #' path <- system.file("examples", "mini_registry.json", package = "gq")
@@ -63,6 +67,7 @@ gq_tmap_style <- function(layer_or_reg, name = NULL, field = NULL) {
 #' cls$values
 #' cls$labels
 #' cls$widths
+#' cls$dashes
 #'
 #' # Object-based (backwards compatible)
 #' cls <- gq_tmap_classes(reg$layers$road)
@@ -73,7 +78,7 @@ gq_tmap_classes <- function(layer_or_reg, name = NULL, field = NULL) {
   cls <- sty$classification
   if (is.null(cls)) stop("Layer does not have classification")
   list(field = cls$field, values = cls$values, labels = cls$labels,
-       widths = cls$widths)
+       widths = cls$widths, dashes = cls$dashes)
 }
 
 
@@ -127,6 +132,23 @@ tmap_polygon_args <- function(sty) {
   args
 }
 
+#' Map a raw QGIS dash value to a valid tmap/grid `lty`
+#'
+#' The registry stores the raw QGIS dash (named style like "dash dot", or a
+#' custom millimetre pattern like "0.66;2"). R's `lty` only accepts a fixed set
+#' of named types or hex digits, not a mm pattern, so anything that isn't
+#' already a valid named `lty` collapses to "dashed". `NULL`/`NA`/"no"/"solid"
+#' return `NULL` (no dash). The raw pattern stays in the registry for backends
+#' that can use it (mapgl's `line-dasharray`).
+#' @noRd
+dash_to_lty <- function(dash) {
+  if (is.null(dash) || is.na(dash) || dash %in% c("no", "solid")) return(NULL)
+  valid_lty <- c("blank", "solid", "dashed", "dotted", "dotdash",
+                 "longdash", "twodash")
+  if (dash %in% valid_lty) return(dash)
+  "dashed"
+}
+
 #' @noRd
 tmap_line_args <- function(sty) {
   args <- list()
@@ -134,9 +156,8 @@ tmap_line_args <- function(sty) {
     args$col <- sty$stroke$color
     if (!is.null(sty$stroke$width)) args$lwd <- sty$stroke$width
     if (!is.null(sty$stroke$opacity)) args$col_alpha <- sty$stroke$opacity
-    if (!is.null(sty$stroke$dash) && sty$stroke$dash != "no") {
-      args$lty <- sty$stroke$dash
-    }
+    lty <- dash_to_lty(sty$stroke$dash)
+    if (!is.null(lty)) args$lty <- lty
   }
   args
 }

--- a/data-raw/reg_extract_restoration.R
+++ b/data-raw/reg_extract_restoration.R
@@ -1,0 +1,31 @@
+# Extract inst/registry/reg_qgis_restoration.json from the QGIS template.
+#
+# Provenance for the restoration source registry. The source `.qgs` lives in the
+# private `rfp` package (it ships the Mergin/QGIS field templates), so
+# regenerating requires rfp installed. This is a DEV-ONLY / build-time
+# dependency — the committed JSON is the shipped source of truth, and gq
+# consumers (tmap, mapgl, link) never need rfp or the `.qgs`. That decoupling is
+# the point: gq owns the canonical styles; rfp owns the upstream project.
+#
+# Run after changing the extractor (R/gq_qgs_extract.R) or the template, then
+# rebuild the master registry with data-raw/reg_build_main.R:
+#   Rscript data-raw/reg_extract_restoration.R
+#   Rscript data-raw/reg_build_main.R
+
+devtools::load_all()
+
+qgs <- system.file("templates", "bcrestoration_mobile.qgs", package = "rfp")
+if (qgs == "") {
+  stop(
+    "rfp not installed — needed only to regenerate this registry. Install with ",
+    "pak::pak('NewGraphEnvironment/rfp')",
+    call. = FALSE
+  )
+}
+
+reg <- gq_qgs_extract(qgs)
+
+jsonlite::write_json(reg, "inst/registry/reg_qgis_restoration.json",
+                     pretty = TRUE, auto_unbox = TRUE)
+
+message("reg_qgis_restoration.json built: ", length(reg$layers), " layers")

--- a/inst/examples/mini_registry.json
+++ b/inst/examples/mini_registry.json
@@ -51,6 +51,7 @@
           "arterial": {
             "color": "#e67e22",
             "width": 1.5,
+            "dash": "0.66;2",
             "label": "Arterial"
           },
           "__empty__": {

--- a/inst/registry/reg_main.json
+++ b/inst/registry/reg_main.json
@@ -281,7 +281,8 @@
       "source_layer": "whse_mineral_tenure.og_pipeline_segment_permit_sp",
       "stroke": {
         "color": "#000000",
-        "width": 0.66
+        "width": 0.66,
+        "dash": "0.66;2"
       }
     },
     "pipeline_permit": {
@@ -420,60 +421,70 @@
           "RR": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RR1": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RRT": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RU": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RRS": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RRD": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RRN": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RRC": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "REC": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "TD": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dot",
             "opacity": 0.6,
             "label": "Trail"
           }
@@ -618,6 +629,7 @@
           "GA24850150": {
             "color": "#a9e0ff",
             "width": 0.3,
+            "dash": "2.5;3.5",
             "label": "Stream - intermittent"
           }
         }
@@ -734,6 +746,7 @@
           "SPAWN;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; no known barriers; intermittent"
           },
           "SPAWN;MODELLED": {
@@ -744,6 +757,7 @@
           "SPAWN;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; potential barrier; intermittent"
           },
           "SPAWN;ASSESSED": {
@@ -754,6 +768,7 @@
           "SPAWN;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; known barrier; intermittent"
           },
           "SPAWN;DAM": {
@@ -764,6 +779,7 @@
           "SPAWN;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; dam; intermittent"
           },
           "SPAWN;REMEDIATED": {
@@ -774,6 +790,7 @@
           "SPAWN;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; remediated; intermittent"
           },
           "REAR;NONE": {
@@ -784,6 +801,7 @@
           "REAR;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; no known barriers; intermittent"
           },
           "REAR;MODELLED": {
@@ -794,6 +812,7 @@
           "REAR;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; potential barrier; intermittent"
           },
           "REAR;ASSESSED": {
@@ -804,6 +823,7 @@
           "REAR;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; known barrier; intermittent"
           },
           "REAR;DAM": {
@@ -814,6 +834,7 @@
           "REAR;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; dam; intermittent"
           },
           "REAR;REMEDIATED": {
@@ -824,6 +845,7 @@
           "REAR;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; remediated; intermittent"
           },
           "ACCESS;NONE": {
@@ -834,6 +856,7 @@
           "ACCESS;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; no known barriers; intermittent"
           },
           "ACCESS;MODELLED": {
@@ -844,6 +867,7 @@
           "ACCESS;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; potential barrier; intermittent"
           },
           "ACCESS;ASSESSED": {
@@ -854,6 +878,7 @@
           "ACCESS;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; known barrier; intermittent"
           },
           "ACCESS;DAM": {
@@ -864,6 +889,7 @@
           "ACCESS;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; dam; intermittent"
           },
           "ACCESS;REMEDIATED": {
@@ -874,6 +900,7 @@
           "ACCESS;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; remediated; intermittent"
           }
         }
@@ -893,6 +920,7 @@
           "SPAWN;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; no known barriers; intermittent"
           },
           "SPAWN;MODELLED": {
@@ -903,6 +931,7 @@
           "SPAWN;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; potential barrier; intermittent"
           },
           "SPAWN;ASSESSED": {
@@ -913,6 +942,7 @@
           "SPAWN;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; known barrier; intermittent"
           },
           "SPAWN;DAM": {
@@ -923,6 +953,7 @@
           "SPAWN;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; dam; intermittent"
           },
           "SPAWN;REMEDIATED": {
@@ -933,6 +964,7 @@
           "SPAWN;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; remediated; intermittent"
           },
           "REAR;NONE": {
@@ -943,6 +975,7 @@
           "REAR;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; no known barriers; intermittent"
           },
           "REAR;MODELLED": {
@@ -953,6 +986,7 @@
           "REAR;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; potential barrier; intermittent"
           },
           "REAR;ASSESSED": {
@@ -963,6 +997,7 @@
           "REAR;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; known barrier; intermittent"
           },
           "REAR;DAM": {
@@ -973,6 +1008,7 @@
           "REAR;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; dam; intermittent"
           },
           "REAR;REMEDIATED": {
@@ -983,6 +1019,7 @@
           "REAR;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; remediated; intermittent"
           },
           "ACCESS;NONE": {
@@ -993,6 +1030,7 @@
           "ACCESS;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; no known barriers; intermittent"
           },
           "ACCESS;MODELLED": {
@@ -1003,6 +1041,7 @@
           "ACCESS;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; potential barrier; intermittent"
           },
           "ACCESS;ASSESSED": {
@@ -1013,6 +1052,7 @@
           "ACCESS;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; known barrier; intermittent"
           },
           "ACCESS;DAM": {
@@ -1023,6 +1063,7 @@
           "ACCESS;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; dam; intermittent"
           },
           "ACCESS;REMEDIATED": {
@@ -1033,6 +1074,7 @@
           "ACCESS;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; remediated; intermittent"
           }
         }
@@ -1052,6 +1094,7 @@
           "SPAWN;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; no known barriers; intermittent"
           },
           "SPAWN;MODELLED": {
@@ -1062,6 +1105,7 @@
           "SPAWN;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; potential barrier; intermittent"
           },
           "SPAWN;ASSESSED": {
@@ -1072,6 +1116,7 @@
           "SPAWN;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; known barrier; intermittent"
           },
           "SPAWN;DAM": {
@@ -1082,6 +1127,7 @@
           "SPAWN;DAM;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; dam; intermittent"
           },
           "SPAWN;REMEDIATED": {
@@ -1092,6 +1138,7 @@
           "SPAWN;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; remediated; intermittent"
           },
           "REAR;NONE": {
@@ -1102,6 +1149,7 @@
           "REAR;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; no known barriers; intermittent"
           },
           "REAR;MODELLED": {
@@ -1112,6 +1160,7 @@
           "REAR;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; potential barrier; intermittent"
           },
           "REAR;ASSESSED": {
@@ -1122,6 +1171,7 @@
           "REAR;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; known barrier; intermittent"
           },
           "REAR;DAM": {
@@ -1132,6 +1182,7 @@
           "REAR;DAM;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; dam; intermittent"
           },
           "REAR;REMEDIATED": {
@@ -1142,6 +1193,7 @@
           "REAR;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; remediated; intermittent"
           },
           "ACCESS;NONE": {
@@ -1152,6 +1204,7 @@
           "ACCESS;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; no known barriers; intermittent"
           },
           "ACCESS;MODELLED": {
@@ -1162,6 +1215,7 @@
           "ACCESS;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; potential barrier; intermittent"
           },
           "ACCESS;ASSESSED": {
@@ -1172,6 +1226,7 @@
           "ACCESS;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; known barrier; intermittent"
           },
           "ACCESS;DAM": {
@@ -1182,6 +1237,7 @@
           "ACCESS;DAM;INTERMITTENT": {
             "color": "#ef4545",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; dam; intermittent"
           },
           "ACCESS;REMEDIATED": {
@@ -1192,6 +1248,7 @@
           "ACCESS;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; remediated; intermittent"
           }
         }

--- a/inst/registry/reg_qgis_restoration.json
+++ b/inst/registry/reg_qgis_restoration.json
@@ -281,7 +281,8 @@
       "source_layer": "whse_mineral_tenure.og_pipeline_segment_permit_sp",
       "stroke": {
         "color": "#000000",
-        "width": 0.66
+        "width": 0.66,
+        "dash": "0.66;2"
       }
     },
     "pipeline_permit": {
@@ -420,60 +421,70 @@
           "RR": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RR1": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RRT": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RU": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RRS": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RRD": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RRN": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "RRC": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "REC": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dash",
             "opacity": 0.6,
             "label": "Resource/recreation/other"
           },
           "TD": {
             "color": "#484848",
             "width": 0.46,
+            "dash": "dot",
             "opacity": 0.6,
             "label": "Trail"
           }
@@ -618,6 +629,7 @@
           "GA24850150": {
             "color": "#a9e0ff",
             "width": 0.3,
+            "dash": "2.5;3.5",
             "label": "Stream - intermittent"
           }
         }
@@ -734,6 +746,7 @@
           "SPAWN;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; no known barriers; intermittent"
           },
           "SPAWN;MODELLED": {
@@ -744,6 +757,7 @@
           "SPAWN;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; potential barrier; intermittent"
           },
           "SPAWN;ASSESSED": {
@@ -754,6 +768,7 @@
           "SPAWN;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; known barrier; intermittent"
           },
           "SPAWN;DAM": {
@@ -764,6 +779,7 @@
           "SPAWN;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; dam; intermittent"
           },
           "SPAWN;REMEDIATED": {
@@ -774,6 +790,7 @@
           "SPAWN;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; remediated; intermittent"
           },
           "REAR;NONE": {
@@ -784,6 +801,7 @@
           "REAR;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; no known barriers; intermittent"
           },
           "REAR;MODELLED": {
@@ -794,6 +812,7 @@
           "REAR;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; potential barrier; intermittent"
           },
           "REAR;ASSESSED": {
@@ -804,6 +823,7 @@
           "REAR;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; known barrier; intermittent"
           },
           "REAR;DAM": {
@@ -814,6 +834,7 @@
           "REAR;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; dam; intermittent"
           },
           "REAR;REMEDIATED": {
@@ -824,6 +845,7 @@
           "REAR;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; remediated; intermittent"
           },
           "ACCESS;NONE": {
@@ -834,6 +856,7 @@
           "ACCESS;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; no known barriers; intermittent"
           },
           "ACCESS;MODELLED": {
@@ -844,6 +867,7 @@
           "ACCESS;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; potential barrier; intermittent"
           },
           "ACCESS;ASSESSED": {
@@ -854,6 +878,7 @@
           "ACCESS;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; known barrier; intermittent"
           },
           "ACCESS;DAM": {
@@ -864,6 +889,7 @@
           "ACCESS;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; dam; intermittent"
           },
           "ACCESS;REMEDIATED": {
@@ -874,6 +900,7 @@
           "ACCESS;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; remediated; intermittent"
           }
         }
@@ -893,6 +920,7 @@
           "SPAWN;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; no known barriers; intermittent"
           },
           "SPAWN;MODELLED": {
@@ -903,6 +931,7 @@
           "SPAWN;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; potential barrier; intermittent"
           },
           "SPAWN;ASSESSED": {
@@ -913,6 +942,7 @@
           "SPAWN;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; known barrier; intermittent"
           },
           "SPAWN;DAM": {
@@ -923,6 +953,7 @@
           "SPAWN;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; dam; intermittent"
           },
           "SPAWN;REMEDIATED": {
@@ -933,6 +964,7 @@
           "SPAWN;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; remediated; intermittent"
           },
           "REAR;NONE": {
@@ -943,6 +975,7 @@
           "REAR;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; no known barriers; intermittent"
           },
           "REAR;MODELLED": {
@@ -953,6 +986,7 @@
           "REAR;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; potential barrier; intermittent"
           },
           "REAR;ASSESSED": {
@@ -963,6 +997,7 @@
           "REAR;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; known barrier; intermittent"
           },
           "REAR;DAM": {
@@ -973,6 +1008,7 @@
           "REAR;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; dam; intermittent"
           },
           "REAR;REMEDIATED": {
@@ -983,6 +1019,7 @@
           "REAR;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; remediated; intermittent"
           },
           "ACCESS;NONE": {
@@ -993,6 +1030,7 @@
           "ACCESS;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; no known barriers; intermittent"
           },
           "ACCESS;MODELLED": {
@@ -1003,6 +1041,7 @@
           "ACCESS;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; potential barrier; intermittent"
           },
           "ACCESS;ASSESSED": {
@@ -1013,6 +1052,7 @@
           "ACCESS;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; known barrier; intermittent"
           },
           "ACCESS;DAM": {
@@ -1023,6 +1063,7 @@
           "ACCESS;DAM;INTERMITTENT": {
             "color": "#ae7dd6",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; dam; intermittent"
           },
           "ACCESS;REMEDIATED": {
@@ -1033,6 +1074,7 @@
           "ACCESS;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; remediated; intermittent"
           }
         }
@@ -1052,6 +1094,7 @@
           "SPAWN;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; no known barriers; intermittent"
           },
           "SPAWN;MODELLED": {
@@ -1062,6 +1105,7 @@
           "SPAWN;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; potential barrier; intermittent"
           },
           "SPAWN;ASSESSED": {
@@ -1072,6 +1116,7 @@
           "SPAWN;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; known barrier; intermittent"
           },
           "SPAWN;DAM": {
@@ -1082,6 +1127,7 @@
           "SPAWN;DAM;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; dam; intermittent"
           },
           "SPAWN;REMEDIATED": {
@@ -1092,6 +1138,7 @@
           "SPAWN;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1.7,
+            "dash": "0.66;2",
             "label": "Spawning; remediated; intermittent"
           },
           "REAR;NONE": {
@@ -1102,6 +1149,7 @@
           "REAR;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; no known barriers; intermittent"
           },
           "REAR;MODELLED": {
@@ -1112,6 +1160,7 @@
           "REAR;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; potential barrier; intermittent"
           },
           "REAR;ASSESSED": {
@@ -1122,6 +1171,7 @@
           "REAR;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; known barrier; intermittent"
           },
           "REAR;DAM": {
@@ -1132,6 +1182,7 @@
           "REAR;DAM;INTERMITTENT": {
             "color": "#ef4545",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; dam; intermittent"
           },
           "REAR;REMEDIATED": {
@@ -1142,6 +1193,7 @@
           "REAR;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 1,
+            "dash": "0.66;2",
             "label": "Rearing; remediated; intermittent"
           },
           "ACCESS;NONE": {
@@ -1152,6 +1204,7 @@
           "ACCESS;NONE;INTERMITTENT": {
             "color": "#129bdb",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; no known barriers; intermittent"
           },
           "ACCESS;MODELLED": {
@@ -1162,6 +1215,7 @@
           "ACCESS;MODELLED;INTERMITTENT": {
             "color": "#ff9f85",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; potential barrier; intermittent"
           },
           "ACCESS;ASSESSED": {
@@ -1172,6 +1226,7 @@
           "ACCESS;ASSESSED;INTERMITTENT": {
             "color": "#ef4545",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; known barrier; intermittent"
           },
           "ACCESS;DAM": {
@@ -1182,6 +1237,7 @@
           "ACCESS;DAM;INTERMITTENT": {
             "color": "#ef4545",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; dam; intermittent"
           },
           "ACCESS;REMEDIATED": {
@@ -1192,6 +1248,7 @@
           "ACCESS;REMEDIATED;INTERMITTENT": {
             "color": "#33a02c",
             "width": 0.4,
+            "dash": "0.66;2",
             "label": "No known barriers; remediated; intermittent"
           }
         }

--- a/man/gq_style.Rd
+++ b/man/gq_style.Rd
@@ -25,7 +25,9 @@ alternatives.}
 A named list with \code{type} and style properties. For simple layers:
 \code{fill}, \code{stroke}, \code{mark} as applicable. For classified layers: adds
 \code{classification} with \code{field}, \code{values} (named color vector), \code{labels},
-and per-class \code{widths}/\code{radii} when available.
+and per-class \code{widths}/\code{radii}/\code{dashes} when available. \code{dashes} holds the
+raw QGIS dash value (named style like "dash dot", or custom pattern like
+"0.66;2") for classes that are dashed.
 }
 \description{
 Resolves a layer by name and returns a plain list of style properties.

--- a/man/gq_tmap_classes.Rd
+++ b/man/gq_tmap_classes.Rd
@@ -23,7 +23,11 @@ alternatives.}
 }
 \value{
 A named list with \code{field}, \code{values} (named color vector), \code{labels},
-and \code{widths} (named line-width vector for line layers; \code{NULL} otherwise).
+\code{widths} (named line-width vector for line layers; \code{NULL} otherwise), and
+\code{dashes} (named raw-QGIS-dash vector for classes that are dashed; \code{NULL}
+otherwise). The dash value is the raw QGIS encoding (named style like
+"dash dot", or custom pattern like "0.66;2") — consumers map it to their
+backend's line type (e.g. tmap \code{lty = "dashed"} for non-NA entries).
 }
 \description{
 For categorized/graduated layers, returns the field, color values, and
@@ -39,6 +43,7 @@ cls$field
 cls$values
 cls$labels
 cls$widths
+cls$dashes
 
 # Object-based (backwards compatible)
 cls <- gq_tmap_classes(reg$layers$road)

--- a/planning/README.md
+++ b/planning/README.md
@@ -1,0 +1,27 @@
+# Planning
+
+Tracks planning-with-files (PWF) artifacts for structured task execution.
+
+## Structure
+
+```
+planning/
+  active/           <- Current work-in-progress PWF files
+    task_plan.md
+    findings.md
+    progress.md
+  archive/          <- Completed issues
+    YYYY-MM-issue-N-slug/
+```
+
+## Workflow
+
+See `feature-workflow.md` convention in CLAUDE.md for the full sequence:
+issue → /planning-init <N> → tests → code-check → atomic commits → /planning-archive.
+
+## Skills
+
+- `/planning-init` — create this structure (you already ran it)
+- `/planning-init <N>` — start issue N (branch + PWF baseline derived from issue body)
+- `/planning-update` — sync checkboxes mid-session
+- `/planning-archive` — archive completed work, create fresh active/

--- a/tests/testthat/fixtures/mini_project.qgs
+++ b/tests/testthat/fixtures/mini_project.qgs
@@ -66,6 +66,9 @@
             <layer class="SimpleLine">
               <Option name="line_color" value="230,126,34,255" type="QString"/>
               <Option name="line_width" value="1.5" type="QString"/>
+              <Option name="line_style" value="solid" type="QString"/>
+              <Option name="use_custom_dash" value="1" type="QString"/>
+              <Option name="customdash" value="0.66;2" type="QString"/>
             </layer>
           </symbol>
         </symbols>

--- a/tests/testthat/test-gq_qgs_extract.R
+++ b/tests/testthat/test-gq_qgs_extract.R
@@ -77,6 +77,47 @@ test_that("gq_qgs_extract parses labels", {
   expect_equal(road$label$halo$width, 1.5)
 })
 
+test_that("gq_qgs_extract captures dash on classified line classes (#32)", {
+  path <- test_path("fixtures", "mini_project.qgs")
+  reg <- gq_qgs_extract(path)
+
+  classes <- reg$layers$roads$classification$classes
+  # arterial uses use_custom_dash=1 + customdash; raw pattern is preserved
+  expect_equal(classes$arterial$dash, "0.66;2")
+  # highway is solid — no dash field
+  expect_null(classes$highway$dash)
+})
+
+test_that("parse_dash reads named, custom, and solid line styles (#32)", {
+  line_layer <- function(...) {
+    opts <- list(...)
+    opt_xml <- paste0(
+      sprintf('<Option name="%s" value="%s"/>', names(opts), unlist(opts)),
+      collapse = ""
+    )
+    xml2::read_xml(paste0(
+      '<layer class="SimpleLine"><Option type="Map">', opt_xml, "</Option></layer>"
+    ))
+  }
+
+  # named style (e.g. transmission_line "dash dot")
+  expect_equal(
+    parse_dash(line_layer(line_style = "dash dot", use_custom_dash = "0")),
+    "dash dot"
+  )
+  # custom dash flag wins even though line_style stays "solid"
+  expect_equal(
+    parse_dash(line_layer(
+      line_style = "solid", use_custom_dash = "1", customdash = "0.66;2"
+    )),
+    "0.66;2"
+  )
+  # plain solid line -> no dash
+  expect_true(is.na(
+    parse_dash(line_layer(line_style = "solid", use_custom_dash = "0"))
+  ))
+})
+
 test_that("gq_qgs_extract errors on missing file", {
   expect_error(gq_qgs_extract("nonexistent.qgs"))
 })

--- a/tests/testthat/test-gq_style.R
+++ b/tests/testthat/test-gq_style.R
@@ -39,6 +39,30 @@ test_that("gq_style returns classified layer with field/values/labels", {
   expect_equal(sty$classification$labels, c("Highway", "Arterial"))
 })
 
+test_that("gq_style surfaces a per-class dashes vector (#32)", {
+  reg <- gq_registry_read(
+    system.file("examples", "mini_registry.json", package = "gq")
+  )
+  sty <- gq_style(reg, "road")
+  # arterial is dashed, highway is not -> dashes present, NA where solid
+  expect_equal(unname(sty$classification$dashes[["arterial"]]), "0.66;2")
+  expect_true(is.na(sty$classification$dashes[["highway"]]))
+  # parallel to widths: one entry per non-__empty__ class
+  expect_length(sty$classification$dashes, 2)
+})
+
+test_that("gq_style omits dashes when no class is dashed (#32)", {
+  layer <- list(
+    type = "line",
+    classification = list(
+      field = "x",
+      classes = list(a = list(color = "#000"), b = list(color = "#111"))
+    )
+  )
+  sty <- gq_style(layer)
+  expect_null(sty$classification$dashes)
+})
+
 test_that("gq_style normalizes display names", {
   reg <- gq_registry_read(
     system.file("examples", "mini_registry.json", package = "gq")

--- a/tests/testthat/test-gq_tmap_style.R
+++ b/tests/testthat/test-gq_tmap_style.R
@@ -25,6 +25,36 @@ test_that("gq_tmap_style returns line args", {
   expect_equal(args$col_alpha, 0.8)
 })
 
+test_that("gq_tmap_style maps a custom dash pattern to lty 'dashed' (#32)", {
+  # raw QGIS mm pattern is not a valid lty -> collapses to "dashed"
+  layer <- list(
+    type = "line",
+    stroke = list(color = "#000", width = 1, dash = "0.66;2")
+  )
+  expect_equal(gq_tmap_style(layer)$lty, "dashed")
+})
+
+test_that("gq_tmap_style passes a valid named lty through, drops solid (#32)", {
+  named <- list(type = "line", stroke = list(color = "#000", dash = "dotted"))
+  expect_equal(gq_tmap_style(named)$lty, "dotted")
+
+  solid <- list(type = "line", stroke = list(color = "#000", dash = "solid"))
+  expect_null(gq_tmap_style(solid)$lty)
+
+  plain <- list(type = "line", stroke = list(color = "#000"))
+  expect_null(gq_tmap_style(plain)$lty)
+})
+
+test_that("dash_to_lty normalizes raw QGIS dashes (#32)", {
+  expect_null(dash_to_lty(NULL))
+  expect_null(dash_to_lty(NA_character_))
+  expect_null(dash_to_lty("solid"))
+  expect_null(dash_to_lty("no"))
+  expect_equal(dash_to_lty("dashed"), "dashed")   # already valid
+  expect_equal(dash_to_lty("dash dot"), "dashed")  # named QGIS, not valid lty
+  expect_equal(dash_to_lty("0.66;2"), "dashed")    # mm pattern
+})
+
 test_that("gq_tmap_style returns point args", {
   layer <- list(
     type = "point",
@@ -73,6 +103,36 @@ test_that("gq_tmap_classes returns classification info", {
   expect_length(cls$values, 2)
   expect_equal(unname(cls$values[["highway"]]), "#c0392b")
   expect_equal(cls$labels, c("Highway", "Arterial"))
+})
+
+test_that("gq_tmap_classes returns a dashes vector for dashed classes (#32)", {
+  layer <- list(
+    type = "line",
+    classification = list(
+      field = "road_type",
+      classes = list(
+        highway = list(color = "#c0392b", label = "Highway"),
+        arterial = list(color = "#e67e22", label = "Arterial", dash = "0.66;2")
+      )
+    )
+  )
+  cls <- gq_tmap_classes(layer)
+  expect_equal(unname(cls$dashes[["arterial"]]), "0.66;2")
+  expect_true(is.na(cls$dashes[["highway"]]))
+})
+
+test_that("gq_tmap_classes dashes is NULL when no class is dashed (#32)", {
+  layer <- list(
+    type = "line",
+    classification = list(
+      field = "road_type",
+      classes = list(
+        highway = list(color = "#c0392b"),
+        arterial = list(color = "#e67e22")
+      )
+    )
+  )
+  expect_null(gq_tmap_classes(layer)$dashes)
 })
 
 test_that("gq_tmap_classes converts fallback labels to title case", {


### PR DESCRIPTION
## Summary

Classified line layers were silently dropping the QGIS dash pattern — every class came out solid even when the source `.qgs` styled some dashed (e.g. `streams_salmon` `;INTERMITTENT` classes). This fixes the end-to-end path: extract → registry → resolvers.

- **Extract** — new shared `parse_dash()` helper. Verified the `.qgs` encodes the intermittent dash as `use_custom_dash="1"` + `customdash="0.66;2"` with `line_style="solid"`, so a literal mirror of the simple branch (which keyed off `line_style=="custom_dash"`) would still miss it. Both the simple and classified `SimpleLine` branches now route through `parse_dash()` — this also fixes the latent custom-dash gap in the simple branch.
- **Registry** — regenerated `reg_qgis_restoration.json` + `reg_main.json`; the diff is strictly dash-only (57 dash lines added, 0 removed, 0 colour/width churn). Added `data-raw/reg_extract_restoration.R` to document provenance (the source `.qgs` lives in the private `rfp` package — a dev-only dependency; the committed JSON is the shipped source of truth).
- **Surface** — `gq_style()` adds a per-class `dashes` vector (parallel to `widths`); `gq_tmap_classes()` returns it. New `dash_to_lty()` maps the raw QGIS value to a valid tmap `lty` (mm pattern / unknown → `"dashed"`, valid named types pass through), so the raw pattern stays in the registry for mapgl's exact `line-dasharray` while tmap stays safe.

Raw QGIS value is stored (per design decision) for maximum downstream flexibility: mapgl consumes the exact pattern; tmap normalizes. `link`'s PARS habitat-connectivity vignette can now drive `lty` from the registry instead of re-deriving it from a `grepl(";INTERMITTENT")`.

Scope kept to line style — distinct from #31 (opacity/casing/outline/radii/shapes).

## Related Issues
- Fixes #32
- Relates to NewGraphEnvironment/sred#13

## Test plan
- [x] `devtools::test()` — 238 pass / 0 fail (installed tmap 4.3 + mapgl 0.4.6 from Suggests)
- [x] `lintr` clean on changed files
- [x] `devtools::check()` — no ERROR; remaining 2 WARN + 2 NOTE are pre-existing and unrelated to #32
- [x] both vignettes re-build OK
- [x] `/code-check` Clean (Phase 1 + Phase 3 fresh-eyes rounds)

## Notes
- `reg_main.json` diff verified programmatically as dash-only.
- New tests: `parse_dash` units + classified-line extraction; `gq_style`/`gq_tmap_classes` `dashes`; `dash_to_lty` mapping.

Generated with Claude Code
