### PR TITLE
Trail symbology in the registry, extracted rather than hand-curated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,25 @@ Teach extreme programming (XP) principles when relevant:
 - **Small commits** — Atomic, focused changes
 - **Test early** — Verify as you go
 
-<\!-- BEGIN SOUL CONVENTIONS — DO NOT EDIT BELOW THIS LINE -->
+<!-- BEGIN SOUL CONVENTIONS — DO NOT EDIT BELOW THIS LINE -->
+
+
+# Always Away
+
+Assume the user is away from the keyboard at all times. Design every operation to run unattended by default; there is no separate "remote work" or "trip prep" mode.
+
+*"Let's assume I'm always away. No special planning for remote work anymore. We are integrated thanks to claude."* (airvine, 2026-07-10)
+
+## Why
+
+The machines are always online and Claude sessions drive them. Distinguishing "user present" from "user traveling" added planning overhead with no payoff — and operations designed for co-presence silently break the moment the user steps away.
+
+## How to apply
+
+- **Unattended by default:** background loops with server-state prechecks, scheduled probes where recovery detection matters, teed logs committed per the log-tracking convention.
+- **Survive the laptop lifecycle:** `caffeinate -i` for long runs — and know its limit: it does not survive lid close. A killed wrapper can orphan child processes that keep working; check `pgrep` before declaring a run dead, and record enough state (PWF, committed logs) that any interruption is resumable.
+- **Gates are phone-answerable:** steps that genuinely need the user (QGIS desktop verification, push approvals, content decisions) are explicit checkpoints answerable from a phone — never assumed co-presence, never blocking questions mid-run.
+- **Every interruption is a resume point:** commit state before long waits; a session death, sleep, or shutdown should cost a re-run at most, never lost context.
 
 
 # Cartography
@@ -408,6 +426,7 @@ Add new checks here when a bug class is discovered — they compound over time.
 - Use `printf '%s\n' "$VAR" | command` to pipe values safely
 - Heredocs: unquoted `<<EOF` expands variables locally, `<<'EOF'` does not — know which you need
 - Pass-through-ssh args: `printf '%q'` escapes per-arg so workload paths with spaces / quotes / metacharacters survive the local-shell → ssh-argv → remote-shell round-trip. Without it, `ssh host 'cmd' "$path"` joins args with spaces on remote and re-parses, losing argument boundaries.
+- `git commit -m "$(cat <<'EOF' ... EOF)"` chokes on apostrophes in prose bodies in some contexts — the bash parser surfaces an unmatched-quote error even though heredoc bodies should be quote-neutral. Resilient default for multi-line commit messages: write the body to `/tmp/msg.txt` and use `git commit -F /tmp/msg.txt`.
 
 ### Heredoc precedence in pipelines
 - `cmd1 | cmd2 <<EOF` — the heredoc binds to `cmd2` (the rightmost simple command). If you intended `cmd1` to receive it, put `<<EOF` on cmd1 explicitly: `cmd1 <<EOF | cmd2`.
@@ -417,6 +436,14 @@ Add new checks here when a bug class is discovered — they compound over time.
 - `set -eu` does NOT propagate exit codes through pipelines. `ssh ... | tee log` returns tee's exit (always 0 for healthy tee), masking ssh failure.
 - Use `set -euo pipefail` for any script that pipes a meaningful command into tee/cat/grep/etc. Or check `${PIPESTATUS[0]}` explicitly.
 - Symptom when wrong: task notifications report "exit 0 / completed" while remote work was actually skipped or errored.
+
+### A wrapper's exit 0 is not "the work completed" — gate on in-band error + output mtime
+- A wrapper reports its OWN exit, not the inner job's. `caffeinate -s bash -c '...'`, `/usr/bin/time -p …`, and background tasks routinely surface **exit 0 / "completed"** while the wrapped R/Python script hit `Execution halted` partway. The interpreter's error goes to the log, not the wrapper's exit code.
+- **Most dangerous in A/B validation:** if the run crashes *before* it (re)writes its output file, a compare step reads the **stale previous output** and reports a false "identical / passed" — a false positive that looks like success.
+- Before trusting any run's result, gate on BOTH:
+  1. **In-band error markers** — `grep -c "Execution halted\|Error:" "$log"` is 0 (R); the language's equivalent otherwise.
+  2. **The output was actually (re)written** — its mtime is newer than a marker touched at run start (`[ output -nt "$marker" ]`), not merely that the file exists.
+- Caught the hard way 2026-07 in `floodplains`: a Pass-2 reuse change was declared "12.4×, byte-identical" and **merged to main** — but the run had `Execution halted` before writing, so the A/B compared the unchanged baseline against its own backup. Broke every step-3 run until hotfixed. Same class as the ssh+tee pipefail symptom above, generalized to any wrapped/background job.
 
 ### Paths
 - Hardcoded absolute paths (`/Users/airvine/...`) break for other users
@@ -428,6 +455,16 @@ Add new checks here when a bug class is discovered — they compound over time.
 - `|| true` hides real errors — is the failure actually safe to ignore?
 - Empty variable before destructive operation (rm, destroy) — add guard: `[ -n "$VAR" ] || exit 1`
 - `grep` returning empty silently — downstream commands get empty input
+
+### Parallel writers sharing one output file interleave mid-record
+- `xargs -P N ... >> shared_file` (or any fan-out where N processes append to the same fd/path) is only safe while each record fits in a single `write()`. O_APPEND makes individual `write()` calls atomic, but a large record (anything beyond pipe/stdio buffer size, ~64 KB) spans multiple writes — concurrent jobs interleave mid-record and corrupt the file.
+- The trap is latent: small records never trip it, so the pattern looks proven until the first large payload arrives. Caught 2026-07-11 in rtj's `stac_register-pypgstac.sh` — 20 parallel `curl | jq -c` jobs appending STAC items to one NDJSON worked for every prior collection (KB-scale items), then 9 MB floodplain items interleaved and produced an orjson decode error ~864 KB into line 1.
+- Fix pattern: each parallel job writes its own temp file (unique name, e.g. md5 of the input), concatenate after the fan-out completes:
+  ```bash
+  cat urls.txt | xargs -P 20 -I {} fetch_one.sh {} "$OUT_DIR"   # each writes $OUT_DIR/<md5>.json
+  cat "$OUT_DIR"/*.json > combined.ndjson
+  ```
+- Pair with a count guard — parallel `curl` failures under xargs are also silent: `[ "$(wc -l < combined.ndjson)" -eq "$EXPECTED" ] || exit 1` before any downstream load.
 
 ### `mktemp` template needs enough X's, and a failed `mktemp` leaves an empty var
 - BSD/macOS `mktemp -d -t <name>` requires the template to contain at least 3 `X`s (`XXXXXX` is the safe default). Without them, mktemp errors to stderr (`too few X's in template`) and **prints nothing to stdout**.
@@ -447,6 +484,11 @@ Add new checks here when a bug class is discovered — they compound over time.
 - **Don't parse `ls`.** BSD `ls` emits ANSI colour codes when stdout is a TTY *or* when `CLICOLOR_FORCE` is set in env (often by shell rc files), and the codes leak through pipes. Downstream `grep`/`sed` chokes on the embedded escapes (`[01;31m...[0m`).
   - Use `find <dir> -maxdepth 1 -mindepth 1 -type d -exec basename {} \;` for directory listings, or `printf '%s\n' <dir>/*/` for a glob, or `for d in <dir>/*/; do basename "$d"; done`.
 - **When writing a snippet you expect to ship in a `skills/` SKILL.md or any cloud-init runcmd**: it must be POSIX-portable. Default to `sed -E`, avoid `\+`/`\|`, and don't pipe `ls`.
+
+### `gh` CLI
+- **`gh pr create` resolves branch from CWD, not `--repo`**. Specifying `--repo NewGraphEnvironment/X` does NOT switch branch resolution — the command still reads the current working directory's checked-out branch. To open a PR in repo X, `cd` into X's checkout first, or pass `--head <branch>` explicitly.
+- **`gh issue create` with heredoc bodies fails on prose containing special shell characters** (apostrophes, dollar signs, backticks). Use `--body-file /tmp/issue.md` instead — every project's `newgraph.md` convention specifies this; codified here for the underlying class.
+- **Before `gh pr merge`, verify the branch is fully pushed.** `gh pr merge` merges the REMOTE branch — commits made locally but never pushed are silently excluded, so the PR merges "successfully" while `main` is missing work you know you committed. Check `git status -sb` shows no `ahead N` before merging (or that `git rev-list --count @{u}..HEAD` is 0). Worse: if you then delete the local branch (`--delete-branch`, or a follow-up `git branch -D`), the unpushed commits become **dangling** — recoverable via `git reflog` / `git fsck --lost-found` then `git cherry-pick`, but only if you notice they're missing. Caught twice 2026-07 in `floodplains`: PR #6 merged 1 of 3 branch commits (the drift#34 `changes_only` fix + a CLAUDE.md update were unpushed → stranded as danglers → recovered and re-merged via a follow-up PR); a second branch sat 4-ahead-unpushed at compact time. The same check belongs in the `gh-pr-merge` skill's pre-merge step.
 
 ### Process Visibility
 - Secrets passed as command-line args are visible in `ps aux`
@@ -605,6 +647,14 @@ Add new checks here when a bug class is discovered — they compound over time.
 - `printf '%q'` escapes values for shell safety
 - Temp files for secrets: create with `chmod 600`, delete after use
 
+### Gitleaks pre-commit hook
+Configuration patterns and false-positive handling for the `gitleaks` pre-commit hook (kdot's Brewfile ships `gitleaks` + `pre-commit`; cyclops standardizes the hook):
+- **`.gitleaks.toml` schema in v8.30+**: top-level table is `[[allowlists]]` (PLURAL, array of tables). Each entry MUST include at least one of `commits` / `paths` / `regexes` / `stopwords`. The singular `[allowlist]` and `fingerprints = [...]` forms shown in older docs fail to validate. Use `paths` + `regexes` together for targeted file-and-content allowlists. Example in `soul/.gitleaks.toml`.
+- **PEM marker regex spans multi-line**: gitleaks's `private-key` rule is `(?i)-----BEGIN...PRIVATE KEY-----[\s\S]*-----END...-----`. It matches across comment prefixes, blank lines, and code-fence boundaries. **Commenting out the markers does NOT neutralize the match.** Only fix in content is to omit the literal `-----BEGIN/END...-----` strings entirely and replace with prose ("Paste your private key here, preserving headers" etc.). See the `rtj` cypher `tfvars.example` precedent.
+- **`curl-auth-header` rule false-positives on non-auth headers**: matches any `-H "X: Y"` shape, not just credential-bearing headers. Trips on docs with custom CORS or app-specific headers (e.g. `Zotero-Allowed-Request: true`). Fix: targeted `[[allowlists]]` with `paths` + `regexes`. Don't path-allowlist the whole file unless content is entirely safe.
+- **`pre-commit install` legacy-hook handling**: running `pre-commit install` on a repo with an existing `.git/hooks/pre-commit` renames it to `.legacy` and keeps invoking it after framework hooks. No breakage, but means hook surface is split between `.pre-commit-config.yaml` and `.git/hooks/pre-commit.legacy`. For full visibility, migrate the legacy check into `.pre-commit-config.yaml` as a `local` hook so the whole hook surface is declared in one place.
+- **AWS canonical example keys are allowlisted by default** (`AKIAIOSFODNN7EXAMPLE` etc.) — don't use those in test fixtures expecting a block. Use `ghp_`-shape PAT lookalikes or other non-allowlisted patterns for hook-trigger tests.
+
 ## R / Package Installation
 
 ### pak Behavior
@@ -625,6 +675,26 @@ Add new checks here when a bug class is discovered — they compound over time.
 - mc#33 example: `mc_label_ensure` used `toupper(nm) %in% sys` (case-insensitive system-label skip), but `resolve_label_names` used `nm %in% sys` (case-sensitive). Result: `add = "inbox"` with `create_missing = TRUE` was silently broken — ensure skipped creation, resolve couldn't match. Fix: both use `toupper(nm) %in% sys` and the resolver normalizes its return to the canonical case.
 - Generalized check: when reviewing a diff that adds normalization (case, whitespace, prefix-trim) on one side of an interaction, grep for the other side and align them.
 
+### Cache keys must cover every output-affecting input
+- A file cache keyed by fewer inputs than the write depends on returns silently wrong data — the worst failure class: no error, plausible-looking output. Enumerate every parameter that changes the written artifact and put each in the key (or its hash). The safe failure direction is over-keying (spurious refetch), never under-keying.
+- drift#25 example: `dft_stac_fetch()` cached STAC rasters as `<source>/<year>.nc` — no AOI in the key. A second watershed silently received the first watershed's raster masked to its own extent (~3% overlap looked plausible enough to almost ship). Fix: filename gains a hash over AOI geometry + `res`/`crs`/`dt`/`aggregation`/`resampling`/`stac_url`/`collection`/`asset`.
+- Hash *resolved* values, not raw args: defaults filled from config (`%||%`) must resolve before hashing, or `f(x)` and `f(x, url = <same-as-default>)` key differently for identical output.
+- R hashing gotchas (`rlang::hash()` serializes, so type and attributes matter):
+  - sf geometry: hash WKB (`sf::st_as_binary(sf::st_geometry(x), endian = "little")`), not the sfc object — sfc carries a PROJ-generated CRS WKT that drifts across PROJ versions (spurious cache misses), and hashing a whole sf data.frame leaks attribute columns into the key. Pass the CRS string as a separate key member.
+  - Coerce numeric types: `10L` and `10` hash differently — `as.numeric()` before hashing.
+- Check the cache's `force`/refresh escape hatch actually overwrites: drift#25's `force = TRUE` errored on the existing file ("File already exists"), broken exactly when needed. Prefer the writer's explicit `overwrite = TRUE` arg over a bare `unlink()` — unlink fails silently on Windows under an open file handle.
+
+### terra: operator dispatch and edge cases in package code
+- **SpatRaster `%in%` is not dispatched when terra is *imported* (only when *attached*).** Inside a package (terra in `Imports`, used via `::`), `some_raster %in% vec` falls through to base `match()` and errors with `'match' requires vector arguments`. A `library(terra)` smoke test passes (attaching installs the S4 method), so the bug hides until package context. Use `terra::subst(x, from, to, others = ...)` or `terra::classify()` for code-set membership/masking instead of the `%in%` operator. Same trap for any operator terra defines via S4 that base also defines as an ordinary function. (drift#34)
+- **`terra::freq()` errors on an all-NA raster** (`replacement has length zero`) rather than returning a 0-row table. Any path that can yield an all-NA layer (an impossible filter, everything masked out) must guard: `f <- tryCatch(terra::freq(r), error = function(e) NULL)`, then treat `NULL`/0 rows as "no values". Don't assume the empty case gives `nrow(freq(r)) == 0`. (drift#34)
+
+### sf: `st_join(largest = TRUE)` ignores the join predicate
+- `sf::st_join(x, y, join = predicate, largest = TRUE)` does **not** use `predicate` to decide matches — with `largest = TRUE`, sf runs `st_intersection(x, y)` and keeps the feature of greatest overlap area, so matching is *always* intersection-based regardless of what `join =` is set to. A function that exposes a configurable predicate AND a largest-overlap mode therefore silently mis-attributes when both are combined: pass `st_within` expecting containment, get anything that merely *overlaps*. Verify against sf source, not the argument list — the `join` arg is accepted and ignored, not rejected. Fix: abort when a non-default predicate is combined with the largest-overlap mode, rather than honouring one and dropping the other. (drift#42)
+- Corollary: `largest = TRUE` also drops zero-area geometries from consideration — so a predicate join against **point** or **line** overlays cannot use largest mode at all (no area to compare). Point/line attribution must go through the plain (`largest = FALSE`) predicate path.
+
+### sf: name validation must account for the geometry column
+- The active geometry column is a named entry in `names(x)`, but its name is **not fixed** — `"geometry"` from `sf::st_read()` of some sources, `"geom"` from a GeoPackage/PostGIS layer, `"geometry"` or `"_ogr_geometry_"` elsewhere. Code that validates user-supplied column names with `cols %in% names(x)` will happily accept the geometry column, then break downstream (`st_join` drops `y`'s geometry, so a requested "attribute" column silently never appears; a 0-row short-circuit path may instead attach a stray empty sfc). A same-name collision check across two sf objects also misses this when the two layers name their geometry differently. Guard explicitly with `attr(x, "sf_column")` — reject it from the caller-supplied column set. (drift#42)
+
 ## General
 
 ### Adopting Existing Config
@@ -635,6 +705,12 @@ When importing config from one location into a canonical one (legacy `~/.bash_pr
   Shell paths: `for p in $(echo "$PATH" | tr ':' ' '); do [ -d "$p" ] || echo "DEAD: $p"; done`
 - **Ask before dropping a reference** — it may be something the user forgot to reinstall on this machine, not something to delete.
 - **Curated subset, not verbatim copy.** The diff should reflect what you verified, not the whole source.
+
+### Test the cold/create path of idempotent code, not just the warm no-op
+- Idempotent provisioning code (a resolver-file writer, a config installer, a "create unless present" block) has two paths: the **cold** path that actually creates/writes, and the **warm** path that detects "already present" and skips. They exercise almost-disjoint code.
+- Testing only on a host where the artifact already exists hits **only the warm no-op** — which cannot catch any cold-path bug: missing-directory, a derivation that returns empty, a pipefail abort before the write, wrong permissions, a flush that never runs. The warm path's job is literally to do nothing, so a green warm test proves almost nothing about onboarding.
+- Every fresh host runs the **cold** path — that's the one onboarding depends on. Test it deliberately: back up + remove the artifact, run cold, assert it was created correctly, then re-run to confirm the warm no-op. (Caught 2026-06-23 on rtj#75: the resolver-writer's first test plan only ran the warm path on a host that already had `/etc/resolver/<suffix>`; a Plan-agent review flagged that the cold path — the one every new host takes — was untested. Fixed by `sudo rm`-ing the file and running cold before close.)
+- Generalizes beyond shell: any "ensure X exists / converge to desired state" operation — Terraform resources, migrations, package installs — wants the from-absent path tested, not just the already-converged re-run.
 
 ### Documentation Staleness
 - Moving/renaming scripts: update CLAUDE.md, READMEs, usage comments
@@ -1340,6 +1416,8 @@ Three tools, different purposes. Use the right one.
 **Citation keys vs item keys:** Citation keys (like `irvine2020ParsnipRiver`) come from Better BibTeX. Item keys (like `K7WALMSY`) are native Zotero. The MCP works with item keys. `/zotero-lookup` bridges citation keys to item data.
 
 **BBT citation key storage:** As of Feb 2025+, BBT stores citation keys as a `citationKey` field directly in `zotero.sqlite` (via Zotero's item data system), not in a separate BBT database. The old `better-bibtex.sqlite` and `better-bibtex.migrated` files are stale and no longer updated. Query citation keys with: `SELECT idv.value FROM items i JOIN itemData id ON i.itemID = id.itemID JOIN itemDataValues idv ON id.valueID = idv.valueID JOIN fields f ON id.fieldID = f.fieldID WHERE f.fieldName = 'citationKey'`.
+
+**BBT citekey format is locally patched to strip `&`:** the `citekeyFormat` pref (`extensions.zotero.translators.better-bibtex.citekeyFormat` in `~/Library/Application Support/Zotero/Profiles/*/prefs.js`) has a `.replace(find = "&", replace = "")` segment added by hand. Without it, institutional authors containing `&` (e.g. "BC Species & Ecosystem Explorer", "WA Dept of Fish & Wildlife") leak `&` into the citekey, and pandoc's `@key` parser stops at `&` — so cites render broken in any bookdown/quarto build even though biblatex accepts the key. Reapply via Zotero → Tools → Run JavaScript: `Zotero.Prefs.set("translators.better-bibtex.citekeyFormat", val)` (also patch `citekeyFormatEditing` to match). Survives Zotero/BBT auto-updates; reverts only on a profile reset or a manual edit via the BBT preferences UI. Detect drift: `grep citekeyFormat ~/Library/Application\ Support/Zotero/Profiles/*/prefs.js` should show the `.replace(find = "&", ...)` chain. Teammates on Skeena/Fraser/restoration machines that hit the same `@key`-breaks-at-`&` drift should run the same `Zotero.Prefs.set`.
 
 ## Adding References Workflow
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gq
 Title: Cartographic Style Management Across Rendering Targets
-Version: 0.1.0
+Version: 0.2.0
 Date: 2026-06-04
 Authors@R: 
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,22 @@
+# gq 0.2.0
+
+- **Trail symbology.** The registry carried no trail, path, footway, cycleway or
+  bridleway layer, so a project that added a trail network had nothing to style
+  it with. `trails` is now a classified line layer on `highway` — the only tag
+  populated on every feature, where `bicycle` sits on 16.4% and would put most
+  features in a fallback class. Classes differ by colour, dash *and* width, so
+  the map reads in printed greyscale as well as in colour.
+- The style is **authored in a QGIS project and extracted**, not hand-written as
+  registry rows. A classified line authored through `reg_custom.csv` comes back
+  with per-class `width` and `dash` both `NULL`, because that path emits
+  `outline_width`/`outline_color` while the translators read `width`/`dash` —
+  and dash is exactly what distinguishes a trail from a road.
+- `data-raw/reg_extract_restoration.R` accepts `RFP_TEMPLATE`, pointing at a
+  source checkout. Without it `system.file()` resolves to the installed package,
+  which is routinely behind: when this style was extracted the installed copy was
+  three releases old and its template carried no trail layer, so the run would
+  have silently produced a registry missing the layer it was made for.
+
 # gq 0.1.0
 
 First release.

--- a/data-raw/reg_extract_restoration.R
+++ b/data-raw/reg_extract_restoration.R
@@ -14,13 +14,29 @@
 
 devtools::load_all()
 
-qgs <- system.file("templates", "bcrestoration_mobile.qgs", package = "rfp")
-if (qgs == "") {
-  stop(
-    "rfp not installed — needed only to regenerate this registry. Install with ",
-    "pak::pak('NewGraphEnvironment/rfp')",
-    call. = FALSE
-  )
+# `RFP_TEMPLATE` points at a template in an rfp SOURCE CHECKOUT, for the case
+# this registry is regenerated against a style that has not been released yet.
+# Without it `system.file()` resolves to the INSTALLED rfp, which is routinely
+# behind: when the trail style was added the installed copy was three releases
+# old and its template carried no trail layer at all, so the extraction would
+# have silently produced a registry missing the very layer it was run for.
+qgs <- Sys.getenv("RFP_TEMPLATE", "")
+if (nzchar(qgs)) {
+  if (!file.exists(qgs)) {
+    stop("RFP_TEMPLATE does not exist: ", qgs, call. = FALSE)
+  }
+  message("Using RFP_TEMPLATE (source checkout): ", qgs)
+} else {
+  qgs <- system.file("templates", "bcrestoration_mobile.qgs", package = "rfp")
+  if (qgs == "") {
+    stop(
+      "rfp not installed — needed only to regenerate this registry. Install with ",
+      "pak::pak('NewGraphEnvironment/rfp'), or set RFP_TEMPLATE to a checkout.",
+      call. = FALSE
+    )
+  }
+  message("Using installed rfp ", as.character(utils::packageVersion("rfp")),
+          ": ", qgs)
 }
 
 reg <- gq_qgs_extract(qgs)

--- a/inst/registry/groups.csv
+++ b/inst/registry/groups.csv
@@ -42,6 +42,7 @@ Roads/Rails/Pipelines,,pipeline_installed,4,bcdata
 Roads/Rails/Pipelines,,pipeline_permit,5,bcdata
 Roads/Rails/Pipelines,,pipeline_application,6,bcdata
 Roads/Rails/Pipelines,,transmission_line,7,bcdata
+Roads/Rails/Pipelines,,trails,8,osm
 Forms,,form_pscis,1,local
 Forms,,form_fiss_site,2,local
 Forms,,form_edna,3,local

--- a/inst/registry/reg_main.json
+++ b/inst/registry/reg_main.json
@@ -208,7 +208,7 @@
       },
       "note": "2 symbol layers — overlay/casing may apply",
       "label": {
-        "font": ".AppleSystemUIFont",
+        "font": "Tahoma",
         "size": 10,
         "color": "#323232",
         "halo": {
@@ -633,6 +633,44 @@
             "label": "Stream - intermittent"
           }
         }
+      }
+    },
+    "trails": {
+      "type": "line",
+      "source_layer": "osm.trail",
+      "classification": {
+        "field": "highway",
+        "classes": {
+          "path": {
+            "color": "#965028",
+            "width": 0.46,
+            "dash": "dash",
+            "label": "Trail"
+          },
+          "footway": {
+            "color": "#8c7864",
+            "width": 0.3,
+            "dash": "dot",
+            "label": "Footpath"
+          },
+          "cycleway": {
+            "color": "#1f78b4",
+            "width": 0.56,
+            "dash": "dash",
+            "label": "Cycleway"
+          },
+          "bridleway": {
+            "color": "#6e6e32",
+            "width": 0.46,
+            "dash": "dash dot",
+            "label": "Bridleway"
+          }
+        }
+      },
+      "label": {
+        "font": "Arial",
+        "size": 6,
+        "color": "#4a4a4a"
       }
     },
     "transmission_line": {

--- a/inst/registry/reg_qgis_restoration.json
+++ b/inst/registry/reg_qgis_restoration.json
@@ -208,7 +208,7 @@
       },
       "note": "2 symbol layers — overlay/casing may apply",
       "label": {
-        "font": ".AppleSystemUIFont",
+        "font": "Tahoma",
         "size": 10,
         "color": "#323232",
         "halo": {
@@ -633,6 +633,44 @@
             "label": "Stream - intermittent"
           }
         }
+      }
+    },
+    "trails": {
+      "type": "line",
+      "source_layer": "osm.trail",
+      "classification": {
+        "field": "highway",
+        "classes": {
+          "path": {
+            "color": "#965028",
+            "width": 0.46,
+            "dash": "dash",
+            "label": "Trail"
+          },
+          "footway": {
+            "color": "#8c7864",
+            "width": 0.3,
+            "dash": "dot",
+            "label": "Footpath"
+          },
+          "cycleway": {
+            "color": "#1f78b4",
+            "width": 0.56,
+            "dash": "dash",
+            "label": "Cycleway"
+          },
+          "bridleway": {
+            "color": "#6e6e32",
+            "width": 0.46,
+            "dash": "dash dot",
+            "label": "Bridleway"
+          }
+        }
+      },
+      "label": {
+        "font": "Arial",
+        "size": 6,
+        "color": "#4a4a4a"
       }
     },
     "transmission_line": {

--- a/tests/testthat/test-gq_trail_style.R
+++ b/tests/testthat/test-gq_trail_style.R
@@ -1,0 +1,96 @@
+# Trail symbology in the registry (#41).
+#
+# The style is authored in rfp's `bcrestoration_mobile.qgs` and reaches here by
+# extraction (`data-raw/reg_extract_restoration.R`), which is what that
+# script's header already describes: gq owns the canonical styles, rfp owns the
+# upstream project. So one authored artifact feeds three consumers - rfp styles
+# every project it creates from the project's own `.qgs`, rfp's vector writer
+# has a style to apply, and this registry gives tmap and mapgl theirs.
+#
+# The route matters and is the reason these tests assert what they do. A
+# classified line authored the other way - by hand in `reg_custom.csv` - comes
+# back with `widths` and `dashes` both NULL, because that writer emits
+# `outline_width`/`outline_color` while `gq_style()` and `gq_tmap_classes()`
+# read per-class `width`/`dash`. Dash is exactly what distinguishes a trail
+# from a road, so the "did it survive" assertions below are not ceremony.
+
+trail <- function() gq_reg_main()$layers$trails
+
+test_that("the registry carries a trail layer", {
+  expect_false(is.null(trail()))
+  expect_equal(trail()$type, "line")
+  expect_equal(trail()$source_layer, "osm.trail")
+})
+
+test_that("it is classified on highway, the only universally populated tag", {
+  # Measured over 13,245 real features: `highway` 100% populated, `bicycle`
+  # 16.4%, `name` 15.3%. Classifying on `bicycle` would put 84% in a fallback
+  # class - and would assert that an unsurveyed tag means prohibited.
+  cls <- trail()$classification
+  expect_equal(cls$field, "highway")
+  expect_setequal(names(cls$classes),
+                  c("path", "footway", "cycleway", "bridleway"))
+})
+
+test_that("per-class width and dash survive into the translators", {
+  # THE test. This is the property the hand-curated CSV route cannot produce -
+  # it returns NULL for both - so a green here is also the evidence for why the
+  # style is authored in a QGIS project and extracted rather than written by
+  # hand as registry rows.
+  cls <- gq_tmap_classes(trail())
+  expect_equal(cls$field, "highway")
+  expect_false(is.null(cls$widths))
+  expect_false(is.null(cls$dashes))
+  expect_length(cls$widths, 4L)
+  expect_length(cls$dashes, 4L)
+  expect_true(all(!is.na(cls$dashes)))
+  expect_true(all(cls$widths > 0))
+})
+
+test_that("classes are distinguishable by more than colour", {
+  # Colour alone fails twice over: printed greyscale, and a phone screen in
+  # direct sun. Asserted as a property - all four distinct on (dash, width) -
+  # rather than by pinning values, so restyling upstream does not fail this
+  # while a collapse into indistinguishable classes still does.
+  cls <- gq_tmap_classes(trail())
+  expect_equal(length(unique(paste(cls$dashes, cls$widths))), 4L)
+  expect_equal(length(unique(cls$values)), 4L)   # ...and by colour too
+})
+
+test_that("each class carries a human label, not the raw OSM tag value", {
+  cls <- gq_tmap_classes(trail())
+  expect_length(cls$labels, 4L)
+  expect_true(all(nzchar(cls$labels)))
+  expect_false(any(cls$labels %in% names(trail()$classification$classes)))
+})
+
+test_that("mapgl gets a usable dash array", {
+  # `gq_mapgl_style()` parses a dash by splitting on ";" or " ", so a raw
+  # customdash string like "5;2" works and a QGIS style NAME like "dash" is
+  # passed through. Asserted because the choice of `line_style` names over
+  # `customdash` was made for tmap's benefit, and must not have broken mapgl.
+  s <- gq_mapgl_style(trail())
+  expect_type(s, "list")
+  expect_gt(length(s), 0L)
+})
+
+test_that("trails are in both templates, in the roads group", {
+  # `groups.csv` is what makes `rfp_project_layers()` return the layer, so a
+  # style with no row here is invisible to project creation.
+  for (t in c("bcfishpass_mobile", "bcrestoration_mobile")) {
+    l <- gq_template_layers(t)
+    r <- l[l$layer_key == "trails", , drop = FALSE]
+    expect_equal(nrow(r), 1L, info = t)
+    expect_equal(r$source_layer[[1]], "osm.trail", info = t)
+    expect_equal(r$source_type[[1]], "osm", info = t)
+    expect_equal(r$group[[1]], "Roads/Rails/Pipelines", info = t)
+  }
+})
+
+test_that("the source_layer matches what rfp downloads", {
+  # `source_layer` is parsed from `layername=` in the template's datasource, and
+  # rfp's osm lookup is keyed by exactly that string. A mismatch means the
+  # project downloads a table the style never reaches.
+  expect_equal(trail()$source_layer, "osm.trail")
+  expect_match(trail()$source_layer, "^[a-z][a-z0-9_]*[.][a-z][a-z0-9_]*$")
+})


### PR DESCRIPTION
## Summary

The registry carried 56 layers and **zero** matching trail, path, footway, cycleway or bridleway, so a project adding a trail network had nothing to style it with. Fixes #41.

## Exploration inverted the dependency this was filed under

#41 assumed gq is upstream for symbology. It is downstream: `data-raw/reg_extract_restoration.R` extracts the registry from rfp's shipped template, and its header already states the contract — *gq owns the canonical styles; rfp owns the upstream project*.

So the style is authored there (NewGraphEnvironment/rfp#171) and reaches here by extraction. One artifact, three consumers: rfp styles every project it creates from the project's own `.qgs`, rfp's vector writer has a style to apply, and this registry gives tmap and mapgl theirs.

## The hand-curated route cannot express a classified line

Probed rather than assumed, through the real code path:

| authored via | `widths` | `dashes` |
|---|---|---|
| `reg_custom.csv` | **NULL** | **NULL** |
| extraction (`roads_dra`) | 26 values | 9 values |

`gq_reg_custom()`'s classified branch emits `outline_width`/`outline_color` where `gq_style()` and `gq_tmap_classes()` read per-class `width`/`dash`. Dash is exactly what distinguishes a trail from a road — so the test asserting both survive is also the evidence for choosing the extraction route. Filed as a defect in its own right: #42.

## What landed

```
trails: line, source_layer osm.trail
  classification on "highway"
    path       #965028  0.46  dash
    footway    #8c7864  0.30  dot
    cycleway   #1f78b4  0.56  dash
    bridleway  #6e6e32  0.46  dash dot
```

Classified on `highway`, populated on **100%** of features where `bicycle` sits on 16.4% — classifying on the latter would put 84% in a fallback class, and would assert that an unsurveyed tag means *prohibited*. Classes differ by colour **and** dash **and** width, because colour alone fails in printed greyscale and on a phone in sun; the test asserts that as a property rather than pinning values, so restyling upstream will not fail the suite while a collapse still does.

`groups.csv` gains a `trails` row under `Roads/Rails/Pipelines` with `source_type = osm`, present in both templates, so `rfp_project_layers()` returns it and new projects download trails.

## One thing worth keeping

`reg_extract_restoration.R` now accepts `RFP_TEMPLATE`, pointing at a source checkout. Without it `system.file()` resolves to the **installed** package — which was three releases behind when this style was extracted, and whose template carried no trail layer at all. The run would have silently produced a registry missing the very layer it was made for.

## Notes

This branch also carries one commit that was sitting unpushed on `main` since 2026-07-26 (a CLAUDE.md conventions sync) — pushing it here un-strands it.

Tests: **267 pass, 0 fail** (238 before, so 29 added). The single warning is pre-existing on `test-gq_registry_read.R`.
