### PR TITLE
Add the four xyz basemaps to the roster, in Base - misc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gq
 Title: Cartographic Style Management Across Rendering Targets
-Version: 0.2.0
+Version: 0.2.1
 Date: 2026-06-04
 Authors@R: 
     person("Allan", "Irvine", , "al@newgraphenvironment.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# gq 0.2.1
+
+- The four xyz basemaps (`esri_world_topo`, `bing_aerial`, `esri_satellite`,
+  `google_satellite`) join the roster in `Base - misc`. They were modelled
+  nowhere before — baked into the upstream templates only — while the two data
+  services in `Web Mapping Services` were already here. Measured against the
+  templates rather than assumed: the six remote layers do **not** share a group.
+
 # gq 0.2.0
 
 - **Trail symbology.** The registry carried no trail, path, footway, cycleway or

--- a/inst/registry/groups.csv
+++ b/inst/registry/groups.csv
@@ -56,3 +56,7 @@ Base - Orthoimagery,,orthophoto_tiles,1,bcdata
 Base - misc,,utm_zones,1,bcdata
 Base - misc,,terrestrial_ecosystem_information_scanned_map_boundary,2,bcdata
 Base - misc,,terrain_mapping_project_boundaries,3,bcdata
+Base - misc,,esri_world_topo,4,wms
+Base - misc,,bing_aerial,5,wms
+Base - misc,,esri_satellite,6,wms
+Base - misc,,google_satellite,7,wms


### PR DESCRIPTION
## Summary

The four xyz basemaps — `esri_world_topo`, `bing_aerial`, `esri_satellite`, `google_satellite` — join the roster. They were modelled **nowhere**: baked into the upstream templates only, while the two data services (`fire_perimeters_current`, `frep_rip2021_mar2022`) were already here in `Web Mapping Services`.

## They go in `Base - misc`, which is measured rather than assumed

The six remote layers do **not** share a layer-tree group:

| group | layers |
|---|---|
| `Web Mapping Services` | Fire Perimeters, FREP — already in the roster |
| `Base - misc` | ESRI World Topo, Bing Aerial, Esri Satellite, Google Satellite |

Putting the basemaps in `Web Mapping Services` would have placed four of six wrongly. This was caught by reading the templates' layer tree back through QGIS, after the downstream code had defaulted all six to one group.

## Why this repo, and only this part

This completes the roster half of the split agreed in NewGraphEnvironment/rfp#161: **gq says which layers a template carries and where; the downstream package owns the provider and uri needed to write one into a project file.** A WMS uri is plumbing rather than symbology — it means nothing to tmap or mapgl, which is what this registry exists to drive.

Verified both templates now return all four:

```
bcfishpass_mobile      basemap rows: 4  group: Base - misc
bcrestoration_mobile   basemap rows: 4  group: Base - misc
```

Tests: **267 pass, 0 fail**, unchanged.
